### PR TITLE
Add --force to the mkdocs gh-deploy call

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          python -m mkdocs gh-deploy
+          python -m mkdocs gh-deploy --force


### PR DESCRIPTION
The action was failing with:
  ! [rejected]        gh-pages -> gh-pages (fetch first)